### PR TITLE
Update Signer.cs

### DIFF
--- a/EInvoicingSigner/Signer.cs
+++ b/EInvoicingSigner/Signer.cs
@@ -234,6 +234,11 @@ public class TokenSigner
                     }
                 }
             }
+            // Added to fix "References"
+            if (request.Type == JTokenType.String)
+            {
+                serialized += JsonConvert.ToString(request.Value<string>());
+            }
         }
         if (request.Type == JTokenType.Object)
         {


### PR DESCRIPTION
The code is not handling array of strings properly, such as the References array:
input:
`"references": ["1234","abcd"],`
proper output should be:
`"REFERENCES""REFERENCES""1234""REFERENCES""abcd"`


I didn't properly test the suggested fix and I think types other than strings should be handled also.